### PR TITLE
Add MapData class for storing map data and constructor arguments to RedBat, BlueSlime, GreenSlime, and OrangeSlime classes

### DIFF
--- a/include/Dungeon/Enemies/Bat.h
+++ b/include/Dungeon/Enemies/Bat.h
@@ -9,7 +9,8 @@ namespace Dungeon {
 namespace Enemies {
 class Bat : public Dungeon::Enemy, private Animation {
 public:
-    Bat(const s_Enemy &u_Enemy);
+    Bat(const s_Enemy &u_Enemy,
+        const std::shared_ptr<SimpleMapData> &simpleMapData);
     virtual ~Bat() = default;
 
     void Move() override;
@@ -17,7 +18,9 @@ public:
     void Update() override;
 
 protected:
-    Bat(const s_Enemy &u_Enemy, const std::string &filepath);
+    Bat(const s_Enemy &u_Enemy,
+        const std::shared_ptr<SimpleMapData> &simpleMapData,
+        const std::string &filepath);
 
     void MoveBat();
     size_t m_Tick = 2;

--- a/include/Dungeon/Enemies/BlueSlime.h
+++ b/include/Dungeon/Enemies/BlueSlime.h
@@ -8,7 +8,8 @@ namespace Dungeon {
 namespace Enemies {
 class BlueSlime final : public Dungeon::Enemy, private Animation {
 public:
-    BlueSlime(const s_Enemy &u_Enemy);
+    BlueSlime(const s_Enemy &u_Enemy,
+              const std::shared_ptr<SimpleMapData> &simpleMapData);
 
     void Move() override;
 

--- a/include/Dungeon/Enemies/GreenSlime.h
+++ b/include/Dungeon/Enemies/GreenSlime.h
@@ -8,7 +8,8 @@ namespace Dungeon {
 namespace Enemies {
 class GreenSlime final : public Dungeon::Enemy, private Animation {
 public:
-    GreenSlime(const s_Enemy &u_Enemy);
+    GreenSlime(const s_Enemy &u_Enemy,
+               const std::shared_ptr<SimpleMapData> &simpleMapData);
 
     void Move() override;
 

--- a/include/Dungeon/Enemies/OrangeSlime.h
+++ b/include/Dungeon/Enemies/OrangeSlime.h
@@ -9,7 +9,8 @@ namespace Dungeon {
 namespace Enemies {
 class OrangeSlime final : public Dungeon::Enemy, private Animation {
 public:
-    OrangeSlime(const s_Enemy &u_Enemy);
+    OrangeSlime(const s_Enemy &u_Enemy,
+                const std::shared_ptr<SimpleMapData> &simpleMapData);
 
     void Move() override;
 

--- a/include/Dungeon/Enemies/RedBat.h
+++ b/include/Dungeon/Enemies/RedBat.h
@@ -7,7 +7,8 @@ namespace Dungeon {
 namespace Enemies {
 class RedBat final : public Bat {
 public:
-    RedBat(const s_Enemy &u_Enemy);
+    RedBat(const s_Enemy &u_Enemy,
+           const std::shared_ptr<SimpleMapData> &simpleMapData);
 };
 } // namespace Enemies
 } // namespace Dungeon

--- a/include/Dungeon/Enemy.h
+++ b/include/Dungeon/Enemy.h
@@ -3,6 +3,7 @@
 
 #include <string>
 
+#include "Dungeon/SimpleMapData.h"
 #include "Dungeon/Tile.h"
 #include "SpriteSheet.hpp"
 #include "ToolBoxs.h"
@@ -13,7 +14,8 @@ namespace Dungeon {
 // Abstract class
 class Enemy : public Util::GameObject {
 public:
-    Enemy(const s_Enemy &u_Enemy);
+    Enemy(const s_Enemy &u_Enemy,
+          const std::shared_ptr<SimpleMapData> &simpleMapData);
     virtual ~Enemy() = default;
 
     void SetShadow(const bool &shadow);
@@ -47,13 +49,18 @@ public:
 
     void MoveToPlayer(); // Set available WillMovePosition to slowly close
                          // PlayerPosition
-
     void TempoMove();
-    virtual void Move() = 0;
+    bool IsVaildMove(const glm::vec2 &position);
+    size_t GamePostion2MapIndex(const glm::ivec2 &position) const {
+        return m_SimpleMapData->GamePostion2MapIndex(position);
+    }
 
+    virtual void Move() = 0;
     virtual void Update(){};
 
 protected:
+    std::shared_ptr<SimpleMapData> m_SimpleMapData;
+
     std::shared_ptr<SpriteSheet> m_SpriteSheet;
     std::vector<std::size_t> m_NormalFrames;
     std::vector<std::size_t> m_ShadowFrames;

--- a/include/Dungeon/EnemyFactory.h
+++ b/include/Dungeon/EnemyFactory.h
@@ -10,7 +10,9 @@
 namespace Dungeon {
 class EnemyFactory {
 public:
-    static std::shared_ptr<Enemy> CreateEnemy(const s_Enemy &u_Enemy) {
+    static std::shared_ptr<Enemy>
+    CreateEnemy(const s_Enemy &u_Enemy,
+                const std::shared_ptr<SimpleMapData> &simpleMapData) {
         // switch (u_Enemy.type) {
         // case 0:
         //     return std::make_shared<Enemies::GreenSlime>(u_Enemy);
@@ -29,7 +31,7 @@ public:
         // default:
         //     return nullptr;
         // }
-        return std::make_shared<Enemies::GreenSlime>(u_Enemy);
+        return std::make_shared<Enemies::GreenSlime>(u_Enemy, simpleMapData);
     }
 };
 } // namespace Dungeon

--- a/include/Dungeon/Map.h
+++ b/include/Dungeon/Map.h
@@ -6,14 +6,11 @@
 #include "Camera.h"
 #include "Dungeon/Enemy.h"
 #include "Dungeon/Level.h"
+#include "Dungeon/MapData.h"
 #include "Dungeon/Tile.h"
 #include "MainCharacter.h"
 
 namespace Dungeon {
-struct s_MapDate {
-    std::vector<std::shared_ptr<Tile>> tiles;
-    std::vector<std::shared_ptr<Enemy>> enemies;
-};
 class Map : public Util::GameObject {
 public:
     Map(const std::shared_ptr<MainCharacter> &mainCharacter,
@@ -36,7 +33,7 @@ private:
     const std::size_t HalfRowNumber = DUNGEON_ROW_NUMBER / 2;
     std::unique_ptr<Level> m_Level;
     glm::ivec2 m_Size;
-    std::vector<s_MapDate> m_MapData; // Use map index to store MapDate
+    std::shared_ptr<MapData> m_MapData; // Use map index to store MapDate
     std::vector<std::shared_ptr<Tile>> m_Tiles;
     std::vector<std::shared_ptr<Enemy>> m_Enemies;
     std::shared_ptr<MainCharacter> m_MainCharacter;

--- a/include/Dungeon/MapData.h
+++ b/include/Dungeon/MapData.h
@@ -1,0 +1,28 @@
+#ifndef MAP_DATA_H
+#define MAP_DATA_H
+
+#include "Dungeon/Enemy.h"
+#include "Dungeon/SimpleMapData.h"
+#include <vector>
+
+namespace Dungeon {
+class MapData final : public SimpleMapData {
+public:
+    MapData(const glm::vec2 &levelIndexMin, const glm::vec2 &levelIndexMax,
+            const glm::vec2 &size);
+
+    void AddEnemy(const size_t &position, const std::shared_ptr<Enemy> &enemy);
+    void RemoveEnemy(const size_t &position,
+                     const std::shared_ptr<Enemy> &enemy);
+    void PopbackEnemy(const size_t &position);
+    bool IsEnemiesEmpty(const size_t &position) const;
+    std::vector<std::shared_ptr<Enemy>>
+    GetEnemies(const size_t &position) const;
+    std::shared_ptr<Enemy> GetEnemyBack(const size_t &position) const;
+
+private:
+    std::vector<std::vector<std::shared_ptr<Enemy>>> m_Enemies;
+};
+} // namespace Dungeon
+
+#endif // MAP_DATA_H

--- a/include/Dungeon/SimpleMapData.h
+++ b/include/Dungeon/SimpleMapData.h
@@ -1,0 +1,40 @@
+#ifndef SIMPLE_MAP_DATA_H
+#define SIMPLE_MAP_DATA_H
+
+#include "Dungeon/Tile.h"
+#include <vector>
+
+namespace Dungeon {
+class SimpleMapData {
+public:
+    SimpleMapData(const glm::ivec2 &levelIndexMin,
+                  const glm::ivec2 &levelIndexMax, const glm::ivec2 &size);
+
+    virtual ~SimpleMapData() = default;
+
+    [[nodiscard]] glm::ivec2 GetLevelIndexMax() const;
+    [[nodiscard]] glm::ivec2 GetLevelIndexMin() const;
+    [[nodiscard]] glm::ivec2 GetSize() const;
+
+    void SetLevelIndexMax(const glm::ivec2 &levelIndexMax);
+    void SetLevelIndexMin(const glm::ivec2 &levelIndexMin);
+    void SetSize(const glm::ivec2 &size);
+
+    size_t GamePostion2MapIndex(const glm::ivec2 &position) const;
+
+    void AddTile(const size_t &position, const std::shared_ptr<Tile> &tile);
+    void RemoveTile(const size_t &position, const std::shared_ptr<Tile> &tile);
+    void PopbackTile(const size_t &position);
+    bool IsTilesEmpty(const size_t &position) const;
+    std::vector<std::shared_ptr<Tile>> GetTiles(const size_t &position) const;
+    std::shared_ptr<Tile> GetTileBack(const size_t &position) const;
+
+private:
+    glm::ivec2 m_LevelIndexMax;
+    glm::ivec2 m_LevelIndexMin;
+    glm::ivec2 m_Size;
+    std::vector<std::vector<std::shared_ptr<Tile>>> m_Tiles;
+};
+} // namespace Dungeon
+
+#endif // SIMPLE_MAP_DATA_H

--- a/src/Dungeon/Enemies/Bat.cpp
+++ b/src/Dungeon/Enemies/Bat.cpp
@@ -1,8 +1,9 @@
 #include "Dungeon/Enemies/Bat.h"
 
 namespace Dungeon {
-Enemies::Bat::Bat(const s_Enemy &u_Enemy)
-    : Enemy(u_Enemy),
+Enemies::Bat::Bat(const s_Enemy &u_Enemy,
+                  const std::shared_ptr<SimpleMapData> &simpleMapData)
+    : Enemy(u_Enemy, simpleMapData),
       Animation(ToolBoxs::GamePostoPos(GetGamePosition())),
       m_RandomGenerator(m_RandomDevice()) {
     m_NormalFrames = {0, 1, 2, 3};
@@ -16,8 +17,10 @@ Enemies::Bat::Bat(const s_Enemy &u_Enemy)
     SetDamage(1); // 0.5 heart
     SetCoin(2);
 }
-Enemies::Bat::Bat(const s_Enemy &u_Enemy, const std::string &filepath)
-    : Enemy(u_Enemy),
+Enemies::Bat::Bat(const s_Enemy &u_Enemy,
+                  const std::shared_ptr<SimpleMapData> &simpleMapData,
+                  const std::string &filepath)
+    : Enemy(u_Enemy, simpleMapData),
       Animation(ToolBoxs::GamePostoPos(GetGamePosition())),
       m_RandomGenerator(m_RandomDevice()) {
     m_NormalFrames = {0, 1, 2, 3};
@@ -59,9 +62,9 @@ void Bat::Update() {
         m_GamePosition = m_WillMovePosition;
         m_NeedToMove = false;
     }
-    else if (!m_CanMove && m_NeedToMove) {
-        RandomMove();
-    }
+    // else if (!m_CanMove && m_NeedToMove) {
+    //     RandomMove();
+    // }
 
     // Update animation
     UpdateAnimation(false);
@@ -78,34 +81,45 @@ void Bat::RandomMove() {
         m_NeedToMove = false;
         return;
     }
-    size_t index = m_Distribution(
-        m_RandomGenerator, std::uniform_int_distribution<size_t>::param_type{
+    size_t index = 0;
+    while (!m_RandomPool.empty()) {
+        index =
+            m_Distribution(m_RandomGenerator,
+                           std::uniform_int_distribution<size_t>::param_type{
                                0, m_RandomPool.size() - 1});
-    switch (m_RandomPool[index]) {
-    case 0:
-        m_WillMovePosition = GetGamePosition() + glm::vec2(0, 1);
-        m_RandomPool.erase(
-            std::remove(m_RandomPool.begin(), m_RandomPool.end(), 0),
-            m_RandomPool.end());
-        return;
-    case 1:
-        m_WillMovePosition = GetGamePosition() + glm::vec2(0, -1);
-        m_RandomPool.erase(
-            std::remove(m_RandomPool.begin(), m_RandomPool.end(), 1),
-            m_RandomPool.end());
-        return;
-    case 2:
-        m_WillMovePosition = GetGamePosition() + glm::vec2(-1, 0);
-        m_RandomPool.erase(
-            std::remove(m_RandomPool.begin(), m_RandomPool.end(), 2),
-            m_RandomPool.end());
-        return;
-    case 3:
-        m_WillMovePosition = GetGamePosition() + glm::vec2(1, 0);
-        m_RandomPool.erase(
-            std::remove(m_RandomPool.begin(), m_RandomPool.end(), 3),
-            m_RandomPool.end());
-        return;
+        switch (m_RandomPool[index]) {
+        case 0:
+            m_WillMovePosition = GetGamePosition() + glm::vec2(0, 1);
+            m_RandomPool.erase(
+                std::remove(m_RandomPool.begin(), m_RandomPool.end(), 0),
+                m_RandomPool.end());
+            break;
+        case 1:
+            m_WillMovePosition = GetGamePosition() + glm::vec2(0, -1);
+            m_RandomPool.erase(
+                std::remove(m_RandomPool.begin(), m_RandomPool.end(), 1),
+                m_RandomPool.end());
+            break;
+        case 2:
+            m_WillMovePosition = GetGamePosition() + glm::vec2(-1, 0);
+            m_RandomPool.erase(
+                std::remove(m_RandomPool.begin(), m_RandomPool.end(), 2),
+                m_RandomPool.end());
+            break;
+        case 3:
+            m_WillMovePosition = GetGamePosition() + glm::vec2(1, 0);
+            m_RandomPool.erase(
+                std::remove(m_RandomPool.begin(), m_RandomPool.end(), 3),
+                m_RandomPool.end());
+            break;
+        }
+        if (IsVaildMove(m_WillMovePosition)) {
+            m_CanMove = true;
+            return;
+        }
+        else {
+            m_CanMove = false;
+        }
     }
 }
 } // namespace Dungeon::Enemies

--- a/src/Dungeon/Enemies/BlueSlime.cpp
+++ b/src/Dungeon/Enemies/BlueSlime.cpp
@@ -1,8 +1,9 @@
 #include "Dungeon/Enemies/BlueSlime.h"
 
 namespace Dungeon {
-Enemies::BlueSlime::BlueSlime(const s_Enemy &u_Enemy)
-    : Enemy(u_Enemy),
+Enemies::BlueSlime::BlueSlime(
+    const s_Enemy &u_Enemy, const std::shared_ptr<SimpleMapData> &simpleMapData)
+    : Enemy(u_Enemy, simpleMapData),
       Animation(ToolBoxs::GamePostoPos(GetGamePosition())) {
     m_NormalFrames = {4, 5, 6, 7};
     m_ShadowFrames = {12, 13, 14, 15};
@@ -37,6 +38,13 @@ void BlueSlime::Move() {
         m_NeedToMove = true;
         m_AnimationType = 2;
     }
+    if (IsVaildMove(m_WillMovePosition)) {
+        m_CanMove = true;
+    }
+    else {
+        m_CanMove = false;
+    }
+
     m_State++;
 }
 void BlueSlime::Update() {

--- a/src/Dungeon/Enemies/GreenSlime.cpp
+++ b/src/Dungeon/Enemies/GreenSlime.cpp
@@ -1,8 +1,9 @@
 #include "Dungeon/Enemies/GreenSlime.h"
 
 namespace Dungeon {
-Enemies::GreenSlime::GreenSlime(const s_Enemy &u_Enemy)
-    : Enemy(u_Enemy),
+Enemies::GreenSlime::GreenSlime(
+    const s_Enemy &u_Enemy, const std::shared_ptr<SimpleMapData> &simpleMapData)
+    : Enemy(u_Enemy, simpleMapData),
       Animation(ToolBoxs::GamePostoPos(GetGamePosition())) {
     m_NormalFrames = {0, 1, 2, 3};
     m_ShadowFrames = {4, 5, 6, 7};

--- a/src/Dungeon/Enemies/OrangeSlime.cpp
+++ b/src/Dungeon/Enemies/OrangeSlime.cpp
@@ -1,8 +1,9 @@
 #include "Dungeon/Enemies/OrangeSlime.h"
 
 namespace Dungeon {
-Enemies::OrangeSlime::OrangeSlime(const s_Enemy &u_Enemy)
-    : Enemy(u_Enemy),
+Enemies::OrangeSlime::OrangeSlime(
+    const s_Enemy &u_Enemy, const std::shared_ptr<SimpleMapData> &simpleMapData)
+    : Enemy(u_Enemy, simpleMapData),
       Animation(ToolBoxs::GamePostoPos(GetGamePosition())),
       m_RandomGenerator(m_RandomDevice()),
       m_Distribution(0, 3) {
@@ -52,6 +53,13 @@ void OrangeSlime::Move() {
         m_WillMovePosition = m_Movement[(m_StartIdx + m_State) % 4];
         m_NeedToMove = true;
     }
+    if (IsVaildMove(m_WillMovePosition)) {
+        m_CanMove = true;
+    }
+    else {
+        m_CanMove = false;
+    }
+
     m_State++;
 }
 void OrangeSlime::Update() {

--- a/src/Dungeon/Enemies/RedBat.cpp
+++ b/src/Dungeon/Enemies/RedBat.cpp
@@ -1,8 +1,9 @@
 #include "Dungeon/Enemies/RedBat.h"
 
 namespace Dungeon {
-Enemies::RedBat::RedBat(const s_Enemy &u_Enemy)
-    : Bat(u_Enemy, ASSETS_DIR "/entities/bat_red.png") {
+Enemies::RedBat::RedBat(const s_Enemy &u_Enemy,
+                        const std::shared_ptr<SimpleMapData> &simpleMapData)
+    : Bat(u_Enemy, simpleMapData, ASSETS_DIR "/entities/bat_red.png") {
 
     SetHealth(2); // 1 heart
     SetDamage(1); // 1 heart

--- a/src/Dungeon/Enemy.cpp
+++ b/src/Dungeon/Enemy.cpp
@@ -3,8 +3,10 @@
 
 namespace Dungeon {
 
-Enemy::Enemy(const s_Enemy &u_Enemy)
-    : m_GamePosition({u_Enemy.x, u_Enemy.y}),
+Enemy::Enemy(const s_Enemy &u_Enemy,
+             const std::shared_ptr<SimpleMapData> &simpleMapData)
+    : m_SimpleMapData(simpleMapData),
+      m_GamePosition({u_Enemy.x, u_Enemy.y}),
       m_BeatDelay(u_Enemy.beatDelay),
       m_Lord(u_Enemy.lord == 1) {
     m_Transform.scale = {DUNGEON_SCALE, DUNGEON_SCALE};
@@ -39,6 +41,15 @@ void Enemy::TempoMove() {
         return;
     }
     Move();
+}
+
+bool Enemy::IsVaildMove(const glm::vec2 &position) {
+    if (m_SimpleMapData
+            ->GetTileBack(m_SimpleMapData->GamePostion2MapIndex(position))
+            ->IsWall()) {
+        return false;
+    }
+    return true;
 }
 
 } // namespace Dungeon

--- a/src/Dungeon/MapData.cpp
+++ b/src/Dungeon/MapData.cpp
@@ -1,0 +1,40 @@
+#include "Dungeon/MapData.h"
+
+namespace Dungeon {
+MapData::MapData(const glm::vec2 &levelIndexMin, const glm::vec2 &levelIndexMax,
+                 const glm::vec2 &size)
+    : SimpleMapData(levelIndexMin, levelIndexMax, size) {
+    m_Enemies.resize(GetSize().x * GetSize().y);
+}
+
+void MapData::AddEnemy(const size_t &position,
+                       const std::shared_ptr<Enemy> &enemy) {
+    m_Enemies.at(position).push_back(enemy);
+}
+
+void MapData::RemoveEnemy(const size_t &position,
+                          const std::shared_ptr<Enemy> &enemy) {
+    m_Enemies.at(position).erase(std::remove(m_Enemies.at(position).begin(),
+                                             m_Enemies.at(position).end(),
+                                             enemy),
+                                 m_Enemies.at(position).end());
+}
+
+void MapData::PopbackEnemy(const size_t &position) {
+    m_Enemies.at(position).pop_back();
+}
+
+bool MapData::IsEnemiesEmpty(const size_t &position) const {
+    return m_Enemies.at(position).empty();
+}
+
+std::vector<std::shared_ptr<Enemy>>
+MapData::GetEnemies(const size_t &position) const {
+    return m_Enemies.at(position);
+}
+
+std::shared_ptr<Enemy> MapData::GetEnemyBack(const size_t &position) const {
+    return m_Enemies.at(position).back();
+}
+
+} // namespace Dungeon

--- a/src/Dungeon/SimpleMapData.cpp
+++ b/src/Dungeon/SimpleMapData.cpp
@@ -1,0 +1,67 @@
+#include "Dungeon/SimpleMapData.h"
+
+namespace Dungeon {
+SimpleMapData::SimpleMapData(const glm::ivec2 &levelIndexMin,
+                             const glm::ivec2 &levelIndexMax,
+                             const glm::ivec2 &size)
+    : m_LevelIndexMin(levelIndexMin),
+      m_LevelIndexMax(levelIndexMax),
+      m_Size(size) {
+    m_Tiles.resize(m_Size.x * m_Size.y);
+}
+void SimpleMapData::AddTile(const size_t &position,
+                            const std::shared_ptr<Tile> &tile) {
+    m_Tiles.at(position).push_back(tile);
+}
+void SimpleMapData::RemoveTile(const size_t &position,
+                               const std::shared_ptr<Tile> &tile) {
+    m_Tiles.at(position).erase(std::remove(m_Tiles.at(position).begin(),
+                                           m_Tiles.at(position).end(), tile),
+                               m_Tiles.at(position).end());
+}
+void SimpleMapData::PopbackTile(const size_t &position) {
+    m_Tiles.at(position).pop_back();
+}
+bool SimpleMapData::IsTilesEmpty(const size_t &position) const {
+    return m_Tiles.at(position).empty();
+}
+
+std::vector<std::shared_ptr<Tile>>
+SimpleMapData::GetTiles(const size_t &position) const {
+    return m_Tiles.at(position);
+}
+
+std::shared_ptr<Tile> SimpleMapData::GetTileBack(const size_t &position) const {
+    return m_Tiles.at(position).back();
+}
+
+glm::ivec2 SimpleMapData::GetLevelIndexMax() const {
+    return m_LevelIndexMax;
+}
+
+glm::ivec2 SimpleMapData::GetLevelIndexMin() const {
+    return m_LevelIndexMin;
+}
+
+void SimpleMapData::SetLevelIndexMax(const glm::ivec2 &levelIndexMax) {
+    m_LevelIndexMax = levelIndexMax;
+}
+
+void SimpleMapData::SetLevelIndexMin(const glm::ivec2 &levelIndexMin) {
+    m_LevelIndexMin = levelIndexMin;
+}
+
+size_t SimpleMapData::GamePostion2MapIndex(const glm::ivec2 &position) const {
+    return (position.x - GetLevelIndexMin().x + 1) +
+           (position.y - GetLevelIndexMin().y + 1) * m_Size.x;
+}
+
+glm::ivec2 SimpleMapData::GetSize() const {
+    return m_Size;
+}
+
+void SimpleMapData::SetSize(const glm::ivec2 &size) {
+    m_Size = size;
+}
+
+} // namespace Dungeon


### PR DESCRIPTION
This pull request adds a new MapData class that is responsible for storing map data. It also adds constructor arguments to the RedBat, BlueSlime, GreenSlime, and OrangeSlime classes to accept a shared pointer to a SimpleMapData object. This allows the enemies to access the map data and make valid moves.