### PR TITLE
Implement A* algorithm for pathfinding in Dungeon module

### DIFF
--- a/include/Dungeon/AStar.h
+++ b/include/Dungeon/AStar.h
@@ -1,0 +1,28 @@
+#ifndef AStar_H
+#define AStar_H
+
+#include "Dungeon/SimpleMapData.h"
+
+namespace Dungeon {
+class AStar final {
+public:
+    static std::vector<glm::ivec2>
+    FindPath(const glm::ivec2 &start, const glm::ivec2 &end,
+             const std::shared_ptr<SimpleMapData> &mapData);
+
+private:
+    struct NodeCompare {
+        bool operator()(const std::pair<float, glm::ivec2> &lhs,
+                        const std::pair<float, glm::ivec2> &rhs) {
+            return lhs.first > rhs.first;
+        }
+    };
+    static float Heuristic(const glm::ivec2 &start, const glm::ivec2 &end);
+    static std::vector<glm::ivec2>
+    CalculatePath(const std::vector<glm::ivec2> &cameFrom,
+                  const glm::ivec2 &start, const glm::ivec2 &end,
+                  const std::shared_ptr<SimpleMapData> &mapData);
+};
+} // namespace Dungeon
+
+#endif // AStar_H

--- a/include/Dungeon/SimpleMapData.h
+++ b/include/Dungeon/SimpleMapData.h
@@ -22,6 +22,7 @@ public:
 
     size_t GamePostion2MapIndex(const glm::ivec2 &position) const;
     bool IsPositionValid(const glm::ivec2 &position) const;
+    bool IsHasEntity(const size_t &position) const;
 
     void AddTile(const size_t &position, const std::shared_ptr<Tile> &tile);
     void RemoveTile(const size_t &position, const std::shared_ptr<Tile> &tile);
@@ -30,10 +31,14 @@ public:
     std::vector<std::shared_ptr<Tile>> GetTiles(const size_t &position) const;
     std::shared_ptr<Tile> GetTileBack(const size_t &position) const;
 
+protected:
+    void SetHasEntity(const size_t &position, const bool &hasEntity);
+
 private:
     glm::ivec2 m_LevelIndexMin;
     glm::ivec2 m_LevelIndexMax;
     glm::ivec2 m_Size;
+    std::vector<bool> m_HasEntity;
     std::vector<std::vector<std::shared_ptr<Tile>>> m_Tiles;
 };
 } // namespace Dungeon

--- a/include/Dungeon/SimpleMapData.h
+++ b/include/Dungeon/SimpleMapData.h
@@ -21,6 +21,7 @@ public:
     void SetSize(const glm::ivec2 &size);
 
     size_t GamePostion2MapIndex(const glm::ivec2 &position) const;
+    bool IsPositionValid(const glm::ivec2 &position) const;
 
     void AddTile(const size_t &position, const std::shared_ptr<Tile> &tile);
     void RemoveTile(const size_t &position, const std::shared_ptr<Tile> &tile);

--- a/include/Dungeon/Tile.h
+++ b/include/Dungeon/Tile.h
@@ -19,6 +19,7 @@ public:
     std::size_t GetIndex();
     s_Tile GetTile();
     bool IsWall();
+    bool IsDoor();
 
     void UpdateDrawable();
 

--- a/src/Dungeon/AStar.cpp
+++ b/src/Dungeon/AStar.cpp
@@ -1,0 +1,93 @@
+#include "Dungeon/AStar.h"
+
+#include <algorithm>
+#include <queue>
+#include <unordered_set>
+
+namespace Dungeon {
+std::vector<glm::ivec2>
+AStar::FindPath(const glm::ivec2 &start, const glm::ivec2 &end,
+                const std::shared_ptr<SimpleMapData> &mapData) {
+    std::vector<glm::ivec2> path;
+    std::vector<glm::ivec2> directions = {
+        {0, 1},
+        {0, -1},
+        {1, 0},
+        {-1, 0},
+    };
+
+    std::priority_queue<std::pair<float, glm::ivec2>,
+                        std::vector<std::pair<float, glm::ivec2>>, NodeCompare>
+        frontier;
+    frontier.push({0, start});
+
+    std::vector<glm::ivec2> cameFrom(mapData->GetSize().x *
+                                     mapData->GetSize().y);
+    LOG_INFO("{0} {1} {2}", mapData->GetSize().x, mapData->GetSize().y,
+             mapData->GetSize().x * mapData->GetSize().y);
+
+    std::vector<float> costSoFar(mapData->GetSize().x * mapData->GetSize().y,
+                                 std::numeric_limits<float>::max());
+    costSoFar[mapData->GamePostion2MapIndex(start)] = 0;
+
+    while (!frontier.empty()) {
+        auto current = frontier.top().second;
+        frontier.pop();
+
+        if (current == end) {
+            path = CalculatePath(cameFrom, start, end, mapData);
+            break;
+        }
+
+        for (const auto &direction : directions) {
+            glm::ivec2 next = current + direction;
+            LOG_INFO("{0} {1} {2}", next.x, next.y,
+                     mapData->GamePostion2MapIndex(next));
+
+            if (mapData->IsPositionValid(next) == false) {
+                continue;
+            }
+
+            if (mapData->IsTilesEmpty(mapData->GamePostion2MapIndex(next))) {
+                continue;
+            }
+
+            if (mapData->GetTileBack(mapData->GamePostion2MapIndex(next))
+                    ->IsWall()) {
+                continue;
+            }
+
+            float newCost = costSoFar[mapData->GamePostion2MapIndex(current)] +
+                            Heuristic(current, next);
+
+            if (newCost < costSoFar[mapData->GamePostion2MapIndex(next)]) {
+                costSoFar[mapData->GamePostion2MapIndex(next)] = newCost;
+                float priority = newCost + Heuristic(next, end);
+                frontier.push({priority, next});
+                cameFrom[mapData->GamePostion2MapIndex(next)] = current;
+            }
+        }
+    }
+
+    return path;
+}
+
+float AStar::Heuristic(const glm::ivec2 &start, const glm::ivec2 &end) {
+    return glm::distance(glm::vec2(start), glm::vec2(end));
+}
+
+std::vector<glm::ivec2>
+AStar::CalculatePath(const std::vector<glm::ivec2> &cameFrom,
+                     const glm::ivec2 &start, const glm::ivec2 &end,
+                     const std::shared_ptr<SimpleMapData> &mapData) {
+    std::vector<glm::ivec2> path;
+    glm::ivec2 current = end;
+    while (current != start) {
+        path.push_back(current);
+        current = cameFrom[mapData->GamePostion2MapIndex(current)];
+    }
+    path.push_back(start);
+    std::reverse(path.begin(), path.end());
+    return path;
+}
+} // namespace Dungeon

--- a/src/Dungeon/AStar.cpp
+++ b/src/Dungeon/AStar.cpp
@@ -23,8 +23,6 @@ AStar::FindPath(const glm::ivec2 &start, const glm::ivec2 &end,
 
     std::vector<glm::ivec2> cameFrom(mapData->GetSize().x *
                                      mapData->GetSize().y);
-    LOG_INFO("{0} {1} {2}", mapData->GetSize().x, mapData->GetSize().y,
-             mapData->GetSize().x * mapData->GetSize().y);
 
     std::vector<float> costSoFar(mapData->GetSize().x * mapData->GetSize().y,
                                  std::numeric_limits<float>::max());
@@ -41,8 +39,6 @@ AStar::FindPath(const glm::ivec2 &start, const glm::ivec2 &end,
 
         for (const auto &direction : directions) {
             glm::ivec2 next = current + direction;
-            LOG_INFO("{0} {1} {2}", next.x, next.y,
-                     mapData->GamePostion2MapIndex(next));
 
             if (mapData->IsPositionValid(next) == false) {
                 continue;
@@ -54,6 +50,11 @@ AStar::FindPath(const glm::ivec2 &start, const glm::ivec2 &end,
 
             if (mapData->GetTileBack(mapData->GamePostion2MapIndex(next))
                     ->IsWall()) {
+                continue;
+            }
+
+            if (mapData->GetTileBack(mapData->GamePostion2MapIndex(next))
+                    ->IsDoor()) {
                 continue;
             }
 

--- a/src/Dungeon/AStar.cpp
+++ b/src/Dungeon/AStar.cpp
@@ -39,22 +39,26 @@ AStar::FindPath(const glm::ivec2 &start, const glm::ivec2 &end,
 
         for (const auto &direction : directions) {
             glm::ivec2 next = current + direction;
-
+            // if the position is invalid
             if (mapData->IsPositionValid(next) == false) {
                 continue;
             }
-
+            // if the tile is empty
             if (mapData->IsTilesEmpty(mapData->GamePostion2MapIndex(next))) {
                 continue;
             }
-
+            // if the tile is a wall
             if (mapData->GetTileBack(mapData->GamePostion2MapIndex(next))
                     ->IsWall()) {
                 continue;
             }
-
+            // if the tile is a door
             if (mapData->GetTileBack(mapData->GamePostion2MapIndex(next))
                     ->IsDoor()) {
+                continue;
+            }
+            // if the tile has entity
+            if (mapData->IsHasEntity(mapData->GamePostion2MapIndex(next))) {
                 continue;
             }
 

--- a/src/Dungeon/MapData.cpp
+++ b/src/Dungeon/MapData.cpp
@@ -10,6 +10,7 @@ MapData::MapData(const glm::vec2 &levelIndexMin, const glm::vec2 &levelIndexMax,
 void MapData::AddEnemy(const size_t &position,
                        const std::shared_ptr<Enemy> &enemy) {
     m_Enemies.at(position).push_back(enemy);
+    SetHasEntity(position, true);
 }
 
 void MapData::RemoveEnemy(const size_t &position,
@@ -18,10 +19,16 @@ void MapData::RemoveEnemy(const size_t &position,
                                              m_Enemies.at(position).end(),
                                              enemy),
                                  m_Enemies.at(position).end());
+    if (m_Enemies.at(position).empty()) {
+        SetHasEntity(position, false);
+    }
 }
 
 void MapData::PopbackEnemy(const size_t &position) {
     m_Enemies.at(position).pop_back();
+    if (m_Enemies.at(position).empty()) {
+        SetHasEntity(position, false);
+    }
 }
 
 bool MapData::IsEnemiesEmpty(const size_t &position) const {

--- a/src/Dungeon/SimpleMapData.cpp
+++ b/src/Dungeon/SimpleMapData.cpp
@@ -8,20 +8,25 @@ SimpleMapData::SimpleMapData(const glm::ivec2 &levelIndexMin,
       m_LevelIndexMax(levelIndexMax),
       m_Size(size) {
     m_Tiles.resize(m_Size.x * m_Size.y);
+    m_HasEntity.resize(m_Size.x * m_Size.y, false);
 }
+
 void SimpleMapData::AddTile(const size_t &position,
                             const std::shared_ptr<Tile> &tile) {
     m_Tiles.at(position).push_back(tile);
 }
+
 void SimpleMapData::RemoveTile(const size_t &position,
                                const std::shared_ptr<Tile> &tile) {
     m_Tiles.at(position).erase(std::remove(m_Tiles.at(position).begin(),
                                            m_Tiles.at(position).end(), tile),
                                m_Tiles.at(position).end());
 }
+
 void SimpleMapData::PopbackTile(const size_t &position) {
     m_Tiles.at(position).pop_back();
 }
+
 bool SimpleMapData::IsTilesEmpty(const size_t &position) const {
     return m_Tiles.at(position).empty();
 }
@@ -63,12 +68,21 @@ bool SimpleMapData::IsPositionValid(const glm::ivec2 &position) const {
            position.y <= GetLevelIndexMax().y;
 }
 
+bool SimpleMapData::IsHasEntity(const size_t &position) const {
+    return m_HasEntity.at(position);
+}
+
 glm::ivec2 SimpleMapData::GetSize() const {
     return m_Size;
 }
 
 void SimpleMapData::SetSize(const glm::ivec2 &size) {
     m_Size = size;
+}
+
+void SimpleMapData::SetHasEntity(const size_t &position,
+                                 const bool &hasEntity) {
+    m_HasEntity.at(position) = hasEntity;
 }
 
 } // namespace Dungeon

--- a/src/Dungeon/SimpleMapData.cpp
+++ b/src/Dungeon/SimpleMapData.cpp
@@ -56,6 +56,13 @@ size_t SimpleMapData::GamePostion2MapIndex(const glm::ivec2 &position) const {
            (position.y - GetLevelIndexMin().y + 1) * m_Size.x;
 }
 
+bool SimpleMapData::IsPositionValid(const glm::ivec2 &position) const {
+    return position.x >= GetLevelIndexMin().x &&
+           position.x <= GetLevelIndexMax().x &&
+           position.y >= GetLevelIndexMin().y &&
+           position.y <= GetLevelIndexMax().y;
+}
+
 glm::ivec2 SimpleMapData::GetSize() const {
     return m_Size;
 }

--- a/src/Dungeon/Tile.cpp
+++ b/src/Dungeon/Tile.cpp
@@ -96,6 +96,11 @@ bool Tile::IsWall() {
            (m_Tile.type >= 112 && m_Tile.type <= 117);
 }
 
+bool Tile::IsDoor() {
+    return m_Tile.type == 103 || m_Tile.type == 106 || m_Tile.type == 111 ||
+           m_Tile.type == 118 || (m_Tile.type >= 50 && m_Tile.type <= 52);
+}
+
 void Tile::UpdateDrawable() {
     int offSetY = 0;
     m_Transform.scale = {DUNGEON_SCALE, DUNGEON_SCALE};

--- a/src/Dungeon/Tile.cpp
+++ b/src/Dungeon/Tile.cpp
@@ -92,7 +92,8 @@ bool Tile::IsWall() {
            m_Tile.type == 104 || m_Tile.type == 105 || m_Tile.type == 107 ||
            m_Tile.type == 108 || m_Tile.type == 109 || m_Tile.type == 110 ||
            m_Tile.type == 119 || m_Tile.type == 120 || m_Tile.type == 121 ||
-           m_Tile.type == 122 || m_Tile.type == 123;
+           m_Tile.type == 122 || m_Tile.type == 123 ||
+           (m_Tile.type >= 112 && m_Tile.type <= 117);
 }
 
 void Tile::UpdateDrawable() {


### PR DESCRIPTION
This pull request adds the A* algorithm for pathfinding in the Dungeon module. 
It includes the implementation of the AStar class, which provides a FindPath() method for finding the shortest path between two points on a map. 
Additionally, it adds the IsPositionValid() and IsHasEntity() methods to the SimpleMapData class for checking if a position is valid and if it has an entity.