### PR TITLE
DungeonMap's TempoTrigger

### DIFF
--- a/include/App.hpp
+++ b/include/App.hpp
@@ -64,6 +64,7 @@ private:
     glm::vec2 m_CameraPosition = {0, 0};
 
     std::shared_ptr<Dungeon::Map> m_DungeonMap;
+    std::size_t m_BeforeTempoIndex = 0;
 };
 
 #endif

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -86,6 +86,11 @@ void App::Update() {
     //        m_Diamond->plusDiamondNumber(10);
     //    }
 
+    if (m_BeforeTempoIndex != m_MusicSystem->getTempoIndex()) {
+        m_BeforeTempoIndex = m_MusicSystem->getTempoIndex();
+        m_DungeonMap->TempoTrigger();
+    }
+
     if (Util::Input::IsKeyDown(Util::Keycode::N)) {
         m_DungeonMap->LoadLevel(m_DungeonMap->GetLevelNum() + 1);
         m_AniCameraDestination = {0, 0};
@@ -187,8 +192,8 @@ void App::Update() {
 
     //    LOG_INFO(rusty_extern_c_integer());
 
-    LOG_INFO("Music's tempo index: {}", m_MusicSystem->getTempoIndex());
-    LOG_INFO("Music's tempo time: {}ms", m_MusicSystem->getTempoTime());
+    // LOG_INFO("Music's tempo index: {}", m_MusicSystem->getTempoIndex());
+    // LOG_INFO("Music's tempo time: {}ms", m_MusicSystem->getTempoTime());
 
     m_MusicSystem->Update();
     m_MainCharacter->Update();


### PR DESCRIPTION
This pull request adds a new member variable, m_BeforeTempoIndex, to the App class. The variable is used to store the previous tempo index of the music system. When the tempo index changes, the DungeonMap's TempoTrigger() function is called. This change improves the functionality of the App class.