### PR TITLE
Fix animation and z-index update in GreenSlime::Update()

### DIFF
--- a/src/Dungeon/Enemies/GreenSlime.cpp
+++ b/src/Dungeon/Enemies/GreenSlime.cpp
@@ -33,8 +33,10 @@ void GreenSlime::Move() {
     m_Animation->MoveByTime(200, ToolBoxs::GamePostoPos(GetGamePosition()), 0);
 }  // Green_Slime does not move
 void GreenSlime::Update() {
+    m_Animation->UpdateAnimation(true);
     if (m_Animation->IsAnimating()) {
         m_Transform.translation = m_Animation->GetAnimationPosition();
     }
+    SetZIndex(m_Animation->GetAnimationZIndex());
 }
 }  // namespace Dungeon::Enemies


### PR DESCRIPTION
This pull request fixes the animation and z-index update issue in the GreenSlime::Update() function. The animation was not updating properly and the z-index was not being set correctly. The issue has been resolved by adding a call to m_Animation->UpdateAnimation(true) to update the animation and setting the z-index using the SetZIndex() function.