### PR TITLE
Fix ZIndex calculation in Enemy, Tile, and Tile subclasses

### DIFF
--- a/src/Dungeon/Enemy.cpp
+++ b/src/Dungeon/Enemy.cpp
@@ -16,7 +16,7 @@ Enemy::Enemy(
     m_Transform.scale = {DUNGEON_SCALE, DUNGEON_SCALE};
     SetGamePosition(m_GamePosition);
     m_Transform.translation = ToolBoxs::GamePostoPos(m_GamePosition);
-    SetZIndex(static_cast<float>(m_GamePosition.y / 1e2 + 1e-4));
+    SetZIndex(static_cast<float>(m_GamePosition.y + 0.125f));
 }
 
 void Enemy::SetShadow(const bool shadow) {

--- a/src/Dungeon/Tile.cpp
+++ b/src/Dungeon/Tile.cpp
@@ -19,7 +19,7 @@ Tile::Tile(const s_Tile& u_Tile, const std::string& filepath)
 }
 
 void Tile::Initialize() {
-    m_ZIndex = (m_Tile.y) / 1e2;
+    m_ZIndex = m_Tile.y;
     m_SpriteSheet = std::make_shared<Util::SpriteSheet>(m_Filepath);
 
     m_TileSize = DUNGEON_TILESIZES.at(m_Tile.type);

--- a/src/Dungeon/Tiles/DoorMetalSide.cpp
+++ b/src/Dungeon/Tiles/DoorMetalSide.cpp
@@ -6,7 +6,6 @@ namespace Dungeon {
 namespace Tiles {
 DoorMetalSide::DoorMetalSide(const s_Tile& u_Tile)
     : GeneralDoorSide(u_Tile, false) {
-    m_ZIndex = m_ZIndex + 1e-4;
     m_MagicNumber = 15;
     UpdateDoorMetalSideDrawable();
 }

--- a/src/Dungeon/Tiles/GeneralDoorFront.cpp
+++ b/src/Dungeon/Tiles/GeneralDoorFront.cpp
@@ -7,7 +7,7 @@ GeneralDoorFront::GeneralDoorFront(
     const bool    generalDoorFront
 )
     : Tile(u_Tile) {
-    m_ZIndex = m_ZIndex + 1e-4;
+    m_ZIndex = m_ZIndex + 0.125f;
     m_MagicNumber = 7;
     if (generalDoorFront) {
         UpdateDrawable();
@@ -20,7 +20,7 @@ GeneralDoorFront::GeneralDoorFront(
     const bool         generalDoorFront
 )
     : Tile(u_Tile, filePath) {
-    m_ZIndex = m_ZIndex + 1e-4;
+    m_ZIndex = m_ZIndex + 0.125f;
     m_MagicNumber = 7;
     if (generalDoorFront) {
         UpdateDrawable();

--- a/src/Dungeon/Tiles/GeneralDoorSide.cpp
+++ b/src/Dungeon/Tiles/GeneralDoorSide.cpp
@@ -7,7 +7,7 @@ GeneralDoorSide::GeneralDoorSide(
     const bool    generalDoorSide
 )
     : Tile(u_Tile) {
-    m_ZIndex = m_ZIndex + 1e-4;
+    m_ZIndex = m_ZIndex + 0.125f;
     m_MagicNumber = 7;
     if (generalDoorSide) {
         UpdateDrawable();

--- a/src/Dungeon/Tiles/WirePhaseConductor.cpp
+++ b/src/Dungeon/Tiles/WirePhaseConductor.cpp
@@ -4,7 +4,7 @@ namespace Dungeon {
 namespace Tiles {
 WirePhaseConductor::WirePhaseConductor(const s_Tile& u_Tile)
     : GeneralFloor(u_Tile, false) {
-    m_ZIndex = m_ZIndex + 1e-4;
+    m_ZIndex = m_ZIndex + 0.125f;
     UpdateDrawable();
 }
 }  // namespace Tiles

--- a/src/Game/Animation.cpp
+++ b/src/Game/Animation.cpp
@@ -11,7 +11,7 @@ Animation::Animation(const glm::vec2& animationPosition)
                                                   - DUNGEON_TILE_WIDTH
                                                   - DUNGEON_TILE_WIDTH})
                           .y;
-    m_AnimationZIndex = static_cast<float>(positionY / 1e2);
+    m_AnimationZIndex = positionY;
 }
 
 void Animation::MoveByTime(
@@ -81,7 +81,7 @@ void Animation::UpdateAnimation(const bool isDirection) {
                                                   - DUNGEON_TILE_WIDTH
                                                   - DUNGEON_TILE_WIDTH})
                           .y;
-    m_AnimationZIndex = static_cast<float>(positionY / 1e2);
+    m_AnimationZIndex = positionY;
 }
 
 bool Animation::IsAnimating() {


### PR DESCRIPTION
This pull request fixes the ZIndex calculation in the Enemy, Tile, and Tile subclasses. The previous calculation was incorrect and has been updated to use the correct values.