### PR TITLE
fix the problem fetch speed too slow

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -10,8 +10,10 @@ include(FetchContent)
 message(STATUS "Tinyxml2 NOT FOUND, fetching from source!")
 FetchContent_Declare(
         tinyxml2
-        GIT_REPOSITORY https://github.com/leethomason/TinyXML2
-        GIT_TAG 9.0.0
+        URL             https://github.com/leethomason/tinyxml2/archive/refs/tags/9.0.0.zip
+        URL_HASH        MD5=2a3b1b8acdc1a0bd15e4010d91c505f8
+        # GIT_REPOSITORY https://github.com/leethomason/TinyXML2
+        # GIT_TAG 9.0.0
 
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinyxml2
 )
@@ -19,8 +21,10 @@ FetchContent_MakeAvailable(tinyxml2)
 
 FetchContent_Declare(
         fmt
-        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG 10.2.1
+        URL             https://github.com/fmtlib/fmt/archive/refs/tags/10.2.1.zip
+        URL_HASH        MD5=1bba4e8bdd7b0fa98f207559ffa380a3
+        # GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+        # GIT_TAG 10.2.1
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/fmt
 )
 FetchContent_MakeAvailable(fmt)
@@ -29,8 +33,10 @@ message(STATUS "PTSD NOT FOUND, fetching from source!")
 set(PTSD_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/PTSD")
 FetchContent_Declare(
         PTSD
-        GIT_REPOSITORY https://github.com/NTUT-FUCK-PTSD/practical-tools-for-simple-design.git
-        GIT_TAG v1.2.7
+        URL             https://github.com/NTUT-FUCK-PTSD/practical-tools-for-simple-design/archive/refs/tags/v1.2.7.zip
+        URL_HASH        MD5=1ac18792e04dc8803b8f30089b781822
+        # GIT_REPOSITORY https://github.com/NTUT-FUCK-PTSD/practical-tools-for-simple-design.git
+        # GIT_TAG v1.2.7
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/PTSD
 )
 FetchContent_MakeAvailable(PTSD)
@@ -41,7 +47,6 @@ message(STATUS "soloud NOT FOUND, fetching from source!")
 FetchContent_Declare(
         soloud
         GIT_REPOSITORY https://github.com/onon1101/soloud.git
-        # GIT_TAG noinst
         GIT_TAG onon1101-patch-2
 
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/soloud


### PR DESCRIPTION
Please watch this issue https://gitlab.kitware.com/cmake/cmake/-/issues/21698

It's mentioned that downloads must utilize a hash to avoid needing verification from the server.