### PR TITLE
Reset coin number and update enemy strike damage

### DIFF
--- a/include/Game/Player.h
+++ b/include/Game/Player.h
@@ -52,6 +52,7 @@ public:
     // set player's item
     void gainCoin(std::size_t number);
     void lostCoin(std::size_t number);
+    void resetCoin();
     void gainDiamond(std::size_t number);
     void lostDiamond(std::size_t number);
 

--- a/include/Game/Warehouse/Coin.h
+++ b/include/Game/Warehouse/Coin.h
@@ -34,6 +34,8 @@ public:
         const uint16_t      direction
     );
 
+    void resetCoinNumber();
+
 private:
     void toLeftSideCoinText();
 

--- a/src/ClickEvent.cpp
+++ b/src/ClickEvent.cpp
@@ -371,6 +371,7 @@ void App::ClickEvent() {
         [this]() {
             m_YouWin->SetVisible(false);
             m_MainCharacter->resetHP();
+            m_MainCharacter->resetCoin();
             bool loadLevel = m_DungeonMap->LoadLevel(1, m_MainCharacter);
             if (loadLevel) {
                 Music::Player::PlayMusic(ASSETS_DIR "/music/zone1_1.ogg", true);

--- a/src/ClickEvent.cpp
+++ b/src/ClickEvent.cpp
@@ -243,7 +243,9 @@ void App::ClickEvent() {
             auto mapIndex = m_DungeonMap->GamePostion2MapIndex(playerDestination
             );
             if (m_DungeonMap->GetMapData()->IsEnemyEmpty(mapIndex)) {
-                m_DungeonMap->GetMapData()->GetEnemy(mapIndex)->Struck(2);
+                m_DungeonMap->GetMapData()->GetEnemy(mapIndex)->Struck(
+                    m_MainCharacter->GetDamage()
+                );
                 m_Camera->Shake(150, 10);
                 m_PlayerMoveDirect = Player::UP;
 

--- a/src/Dungeon/Map/Map.cpp
+++ b/src/Dungeon/Map/Map.cpp
@@ -112,16 +112,16 @@ bool Map::CanPlayerSeePosition(const glm::vec2& position) {
 
     // I don't know why but the target and source position are reversed
     // so I have to reverse them
-    glm::vec2 targetPosition = m_MapData->GetPlayerPosition();
-    glm::vec2 sourcePosition = position;
+    glm::ivec2 targetPosition = m_MapData->GetPlayerPosition();
+    glm::ivec2 sourcePosition = position;
 
-    std::vector<glm::vec2> integerCoordinates;
+    std::vector<glm::ivec2> integerCoordinates;
 
-    glm::vec2 delta = targetPosition - sourcePosition;
-    glm::vec2 sign = glm::sign(delta);
+    glm::ivec2 delta = targetPosition - sourcePosition;
+    glm::ivec2 sign = glm::sign(delta);
     delta = glm::abs(delta);
-    int       error = 0;
-    glm::vec2 current = sourcePosition;
+    int        error = 0;
+    glm::ivec2 current = sourcePosition;
 
     if (delta.x > delta.y) {
         for (int i = 0; i <= delta.x; ++i) {
@@ -150,7 +150,7 @@ bool Map::CanPlayerSeePosition(const glm::vec2& position) {
     // so we have to reverse it
     for (int i = integerCoordinates.size() - 1; i >= 0; --i) {
         mapIndex = m_MapData->GamePosition2MapIndex(integerCoordinates[i]);
-        if (position == integerCoordinates[i]) {
+        if (position == static_cast<glm::vec2>(integerCoordinates[i])) {
             m_ShadowRenderDP[mapIndex] = true;
             return true;
         }

--- a/src/Game/Player.cpp
+++ b/src/Game/Player.cpp
@@ -163,6 +163,10 @@ void Player::lostCoin(std::size_t number) {
     m_Coin->plusCoinNumber(number * -1);
 }
 
+void Player::resetCoin() {
+    m_Coin->resetCoinNumber();
+}
+
 void Player::gainDiamond(std::size_t number) {
     m_Diamond->plusDiamondNumber(number);
 }

--- a/src/Game/Warehouse/Coin.cpp
+++ b/src/Game/Warehouse/Coin.cpp
@@ -56,6 +56,14 @@ void Coin::plusCoinNumber(const int number) {
     toLeftSideCoinText();
 }
 
+void Coin::resetCoinNumber() {
+    m_Number = 0;
+    const std::string str = '*' + std::to_string(m_Number);
+    m_text->SetText(str);
+
+    toLeftSideCoinText();
+}
+
 void Coin::SetPosition(const glm::vec2& position) {
     m_CoinText->SetPosition(position);
     m_CoinImage->SetPosition(position);

--- a/src/Game/Warehouse/Heart.cpp
+++ b/src/Game/Warehouse/Heart.cpp
@@ -112,6 +112,7 @@ void Heart::UpdateHP() {
 void Heart::minusHP(const std::size_t number) {
     if (number > m_currentHP) {
         m_currentHP = 0;
+        UpdateHP();
         return;
     }
     m_currentHP -= number;


### PR DESCRIPTION
This pull request includes the following changes:

- Reset the coin number to 0 when restarting the game.

- Update the enemy strike damage in the ClickEvent.cpp file to use the main character's damage.

These changes ensure that the coin number is properly reset and that the enemy strike damage is calculated correctly.