### PR TITLE
"Add "No Beat" functionality to Dungeon Map"

### DIFF
--- a/include/Dungeon/Map.h
+++ b/include/Dungeon/Map.h
@@ -65,6 +65,8 @@ public:
     void        KingConga();
     std::size_t GetBossRoomValue() const { return m_BossRoom; }
 
+    void NoBeat() { m_NoBeat = true; }
+
 private:
     bool m_Available;
     void LoadTile(std::shared_ptr<Level> level);
@@ -121,6 +123,7 @@ private:
 
     std::size_t m_CoinMultiple = 0;
     std::size_t m_BossRoom = 0;
+    bool        m_NoBeat = false;
 };
 
 }  // namespace Dungeon

--- a/src/ClickEvent.cpp
+++ b/src/ClickEvent.cpp
@@ -417,6 +417,7 @@ void App::ClickEvent() {
             m_NoBeatModeText->SetVisible(m_NoBeatMode);
             Music::Tempo::Pause(m_NoBeatMode);
             Display::BeatIndicator::Pause(m_NoBeatMode);
+            m_DungeonMap->NoBeat();
         },
         Util::Keycode::M
     );

--- a/src/Dungeon/Map/Update.cpp
+++ b/src/Dungeon/Map/Update.cpp
@@ -63,6 +63,12 @@ void Map::PlayerTrigger() {
 }
 
 void Map::TempoTrigger(const std::size_t index) {
+    if (m_NoBeat && m_TempoIndex != index) {
+        m_TempoIndex = index;
+        return;
+    } else {
+        m_NoBeat = false;
+    }
     Event::EventQueue.dispatch(
         this,
         FloorUpdateEventArgs(index, m_CoinMultiple > 0)


### PR DESCRIPTION
This pull request adds a new functionality to the Dungeon Map called "No Beat". When the "No Beat" mode is activated, the map will no longer respond to the beat of the music. This functionality is implemented by adding a new boolean flag `m_NoBeat` to the `Map` class and updating the `ClickEvent` and `TempoTrigger` methods accordingly.