### PR TITLE
HOTFIX: Fix visibility of King Conga chair

### DIFF
--- a/include/Dungeon/Enemies/KingConga.h
+++ b/include/Dungeon/Enemies/KingConga.h
@@ -5,6 +5,7 @@
 
 #include "Dungeon/Enemies/KingCongaBridge.h"
 #include "Dungeon/Enemy.h"
+#include "Util/GameObject.hpp"
 
 namespace Dungeon {
 namespace Enemies {

--- a/src/ClickEvent.cpp
+++ b/src/ClickEvent.cpp
@@ -26,7 +26,6 @@
 #include "Systems/HEIS.h"
 #include "Systems/HandThrow.h"
 
-
 struct ClickEventType {
     std::vector<Util::Keycode> code;
     std::function<void()>      fptr;
@@ -417,8 +416,8 @@ void App::ClickEvent() {
         [this]() {
             m_NoBeatMode = !m_NoBeatMode;
             m_NoBeatModeText->SetVisible(m_NoBeatMode);
-            Music::Tempo::Pause(m_NoBeatMode);
-            Music::IndicatorBar::Pause(m_NoBeatMode);
+            // Music::Tempo::Pause(m_NoBeatMode);
+            // Music::IndicatorBar::Pause(m_NoBeatMode);
             m_DungeonMap->NoBeat();
         },
         Util::Keycode::M

--- a/src/Dungeon/Enemies/KingConga.cpp
+++ b/src/Dungeon/Enemies/KingConga.cpp
@@ -88,6 +88,9 @@ void KingConga::SetState(const State state) {
     case State::WALK:
         m_NormalFrames = m_NormalFramesWalk;
         m_ShadowFrames = m_ShadowFramesWalk;
+        for (auto& elem : m_Children) {
+            elem->SetVisible(true);
+        }
         break;
     }
     m_SpriteSheet->SetFrames(GetShadow() ? m_ShadowFrames : m_NormalFrames);

--- a/src/Dungeon/Map/KingCongaRoom.cpp
+++ b/src/Dungeon/Map/KingCongaRoom.cpp
@@ -42,7 +42,8 @@ void Map::KingConga() {
     chairObj->SetPosition(
         ToolBoxs::GamePostoPos({gamePos.x, gamePos.y}) + glm::vec2(3, 0)
     );
-    chairObj->SetZIndex(kingConga->GetZIndex() - 0.00001);
+    chairObj->SetZIndex(kingConga->GetZIndex());
+    chairObj->SetVisible(false);
     kingConga->AddChild(chairObj);
     // Add Left Ghost
     gamePos = glm::ivec2(-7, -17);


### PR DESCRIPTION
This pull request fixes the visibility of the King Conga chair by setting it to be invisible by default. Previously, the chair was visible even when the King Conga was in a different state. This PR also includes a hotfix for an unspecified issue.