### PR TITLE
feat: Set ZIndex of chair object in KingCongaRoom

### DIFF
--- a/src/Dungeon/Map/KingCongaRoom.cpp
+++ b/src/Dungeon/Map/KingCongaRoom.cpp
@@ -42,7 +42,7 @@ void Map::KingConga() {
     chairObj->SetPosition(
         ToolBoxs::GamePostoPos({gamePos.x, gamePos.y}) + glm::vec2(3, 0)
     );
-    chairObj->SetZIndex(kingConga->GetZIndex());
+    chairObj->SetZIndex(-16.5);
     chairObj->SetVisible(false);
     kingConga->AddChild(chairObj);
     // Add Left Ghost


### PR DESCRIPTION
This commit sets the ZIndex of the chair object in the KingCongaRoom to -16.5. This change ensures that the chair object is rendered correctly in the game.