### PR TITLE
feat: Fix bug in IndicatorBar Update method

### DIFF
--- a/src/Music/IndicatorBar.cpp
+++ b/src/Music/IndicatorBar.cpp
@@ -117,9 +117,10 @@ void Music::IndicatorBar::Update() {
     UpdateIndicatorLeft(m_BeatIndex, m_IIT, m_IIS);
     UpdateIndicatorRight(m_BeatIndex, m_IIT, m_IIS);
 
-    // if (m_BeatIndex + m_TempoNumber >= Music::Tempo::GetBeatListLen()) {
-    //     m_BeatIndex = 0;
-    // } else if (Music::Tempo::GetBeatIdx() != m_BeatIndex) {
+    if (m_BeatIndex + m_TempoNumber >= Music::Tempo::GetBeatListLen()) {
+        m_BeatIndex = 0;
+    }
+    // else if (Music::Tempo::GetBeatIdx() != m_BeatIndex) {
     //     m_BeatIndex++;
     // }
 }


### PR DESCRIPTION
This commit fixes a bug in the Update method of the IndicatorBar class. The bug caused the beat index to not reset correctly when it reached the end of the beat list. The fix ensures that the beat index is set to 0 when it exceeds the beat list length.