### PR TITLE
fix: Reset m_LastIdxLeft and m_LastIdxRight in IndicatorBar Update method

### DIFF
--- a/src/Music/IndicatorBar.cpp
+++ b/src/Music/IndicatorBar.cpp
@@ -119,6 +119,8 @@ void Music::IndicatorBar::Update() {
 
     if (m_BeatIndex + m_TempoNumber >= Music::Tempo::GetBeatListLen()) {
         m_BeatIndex = 0;
+        m_LastIdxLeft = 0;
+        m_LastIdxRight = 0;
     }
     // else if (Music::Tempo::GetBeatIdx() != m_BeatIndex) {
     //     m_BeatIndex++;


### PR DESCRIPTION
The IndicatorBar Update method was not correctly resetting the m_LastIdxLeft and m_LastIdxRight variables when the beat index exceeded the beat list length. This commit fixes the issue by setting both variables to 0 in that scenario.