### PR TITLE
Add flag to Music::IndicatorBar for correct display

### DIFF
--- a/include/Music/IndicatorBar.h
+++ b/include/Music/IndicatorBar.h
@@ -86,6 +86,7 @@ private:
     static std::vector<std::shared_ptr<Animation>> m_AnimationsRight;
     static std::size_t                             m_LastIdxLeft;
     static std::size_t                             m_LastIdxRight;
+    static bool                                    m_Flag;
 };
 }  // namespace Music
 


### PR DESCRIPTION
This pull request adds a flag to the Music::IndicatorBar class to ensure the correct display of the indicator bar. The flag is used to control the animation and position of the left and right indicators based on the current beat index and tempo number. This change improves the accuracy of the indicator bar's display in the game.